### PR TITLE
fix(lint): use correct check for checkout-repo condition

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -17,7 +17,7 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v3
-      if: inputs.checkout-repo
+      if: inputs.checkout-repo == 'true'
       with:
         # Use fetch-depth of zero to obtain all commit history so that commit message linting can
         # be properly performed.


### PR DESCRIPTION

**Description**

The `checkout-repo` check wasn't working as expected and it's because the expression was missing the == check

**Changes**

* fix(lint): use correct check for checkout-repo condition

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
