### PR TITLE
feat: extra-plugins defaults to @open-turo/semantic-release-config

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -13,7 +13,9 @@ inputs:
     description: Whether to run semantic release in `dry-run` mode. It will override the dryRun attribute in your configuration file
   extra-plugins:
     required: false
-    description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.
+    description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.
+    default: |
+      @open-turo/semantic-release-config@^1.4.0
 outputs:
   new-release-published:
     description: Whether a new release was published


### PR DESCRIPTION
We expect that repositories using this action will also be using the @open-turo/semantic-release-config config.  This makes it install by default so that consumers need less configuration.

Additionally, it pins the version to `1.4.0` because there is a node version issue when running `cycjimmy/semantic-release-action`.

fixes #23