### PR TITLE
feat: add action to check for breaking change commits

### DIFF
--- a/check-for-breaking-changes/README.md
+++ b/check-for-breaking-changes/README.md
@@ -1,0 +1,34 @@
+# GitHub Action Check for Breaking Changes
+
+## Description
+
+GitHub Action that check the current branch for any breaking change commits based on the commit message.
+
+## Usage
+
+```yaml
+jobs:
+  test:
+    steps:
+      - name: Enable terraform authentication
+        uses: open-turo/actions-tf/check-for-breaking-changes@v3
+```
+
+## Inputs
+
+| parameter          | description                              | required | default                                          |
+| ------------------ | ---------------------------------------- | -------- | ------------------------------------------------ |
+| checkout-repo      | Perform checkout as first step of action | `false`  | true                                             |
+| commit-base-ref    | Commit range to exclude from check       | `false`  | $GITHUB_BASE_REF                                 |
+| commit-head-ref    | Commit range to include in check         | `false`  | $GITHUB_HEAD_REF                                 |
+| commit-msg-pattern | Pattern used to check                    | `false`  | 'BREAKING:\|BREAKING CHANGE:\|BREAKING CHANGES:' |
+
+## Outputs
+
+| parameter                 | description                                                                          |
+| ------------------------- | ------------------------------------------------------------------------------------ |
+| contains-breaking-changes | Indicates whether or not the action found a ny breaking changes in the commit range. |
+
+## Runs
+
+This action is an `composite` action.

--- a/check-for-breaking-changes/action.yaml
+++ b/check-for-breaking-changes/action.yaml
@@ -1,0 +1,44 @@
+name: check for breaking changes
+description: GitHub Action that check the current branch for any breaking change commits based on the commit message.
+inputs:
+  checkout-repo:
+    required: false
+    description: Perform checkout as first step of action
+    default: "true"
+  commit-base-ref:
+    required: false
+    description: Commit range to exclude from check
+    default: $GITHUB_BASE_REF
+  commit-head-ref:
+    required: false
+    description: Commit range to include in check
+    default: $GITHUB_HEAD_REF
+  commit-msg-pattern:
+    required: false
+    description: Pattern used to check
+    default: 'BREAKING:\|BREAKING CHANGE:\|BREAKING CHANGES:'
+outputs:
+  contains-breaking-changes:
+    description: Indicates whether or not the action found any breaking changes in the commit range.
+    value: ${{ steps.check.outputs.contains-breaking }}
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      if: inputs.checkout-repo == 'true'
+      with:
+        fetch-depth: 0
+
+    - name: Check for breaking changes
+      id: check
+      shell: bash
+      run: |
+        commits=$(git log origin/"${{ inputs.commit-base-ref }}"..origin/"${{ inputs.commit-head-ref }}")
+
+        if echo "$commits" | grep -q "${{ inputs.commit-msg-pattern }}"; then
+          echo "contains-breaking=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "contains-breaking=false" >> "$GITHUB_OUTPUT"
+        fi


### PR DESCRIPTION

**Description**

Adds a composite action which can check in a range of commits if there are any breaking change commits, following the specified pattern.



**Changes**

* feat: add action to check for breaking change commits

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
