### PR TITLE
feat: add action to generate and validate breaking changes document

### DIFF
--- a/check-for-breaking-changes/README.md
+++ b/check-for-breaking-changes/README.md
@@ -10,7 +10,7 @@ GitHub Action that check the current branch for any breaking change commits base
 jobs:
   test:
     steps:
-      - name: Enable terraform authentication
+      - name: Check for breaking changes
         uses: open-turo/actions-tf/check-for-breaking-changes@v3
 ```
 

--- a/generate-breaking-changes-doc/README.md
+++ b/generate-breaking-changes-doc/README.md
@@ -1,0 +1,71 @@
+# GitHub Action Generate Breaking Changes Document
+
+<!-- action-docs-description -->
+
+## Description
+
+GitHub Action that creates a breaking changes document based on the configured template.
+
+<!-- action-docs-description -->
+
+\_\_
+
+## Usage
+
+```yaml
+jobs:
+  check:
+    name: Check for breaking changes
+    runs-on: [self-hosted, general-ubuntu]
+    outputs:
+      contains-breaking-changes: ${{ steps.check.outputs.contains-breaking-changes }}
+    steps:
+      - name: Check for breaking changes
+        id: check
+        uses: open-turo/actions-tf/check-for-breaking-changes@v3
+
+  generate:
+    needs: [check-for-breaking-changes]
+    if: ${{ needs.check.outputs.contains-breaking-changes == 'true' }}
+    name: Generate and validate documentation
+    runs-on: [self-hosted, general-ubuntu]
+    steps:
+      - name: Generate breaking changes document
+        id: generate
+        uses: open-turo/actions-tf/generate-breaking-changes-doc@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+<!-- action-docs-inputs -->
+
+## Inputs
+
+| parameter               | description                                                                                                 | required | default                                                                                                         |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| checkout-repo           | Perform checkout as first step of action                                                                    | `false`  | true                                                                                                            |
+| github-token            | GitHub token that can checkout the consumer repository as well push against it. e.g. 'secrets.GITHUB_TOKEN' | `true`   |                                                                                                                 |
+| template-url            | Breaking changes document template URL                                                                      | `false`  | https://raw.githubusercontent.com/open-turo/standards-terraform/main/templates/breaking-changes-doc-template.md |
+| pr-comment              | Adds a comment to the pull request informing that the breaking changes document was added                   | `false`  | true                                                                                                            |
+| pr-comment-author-name  | The pull request comment author name                                                                        | `false`  |                                                                                                                 |
+| pr-comment-author-email | The pull request comment author email                                                                       | `false`  |                                                                                                                 |
+
+<!-- action-docs-inputs -->
+
+<!-- action-docs-outputs -->
+
+## Outputs
+
+| parameter     | description                                 |
+| ------------- | ------------------------------------------- |
+| document-path | The relative path to the generated document |
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-runs -->
+
+## Runs
+
+This action is a `composite` action.
+
+<!-- action-docs-runs -->

--- a/generate-breaking-changes-doc/action.yaml
+++ b/generate-breaking-changes-doc/action.yaml
@@ -1,0 +1,101 @@
+name: generate breaking changes document
+description: GitHub Action that creates a breaking changes document based on the configured template.
+inputs:
+  checkout-repo:
+    required: false
+    description: Perform checkout as first step of action
+    default: "true"
+  github-token:
+    required: true
+    description: GitHub token that can checkout the consumer repository as well push against it. e.g. 'secrets.GITHUB_TOKEN'
+  template-url:
+    required: false
+    description: Breaking changes document template URL
+    default: https://raw.githubusercontent.com/open-turo/standards-terraform/main/templates/breaking-changes-doc-template.md
+  pr-comment:
+    required: false
+    description: Adds a comment to the pull request informing that the breaking changes document was added
+    default: "true"
+  pr-comment-author-name:
+    required: false
+    description: The pull request comment author name
+  pr-comment-author-email:
+    required: false
+    description: The pull request comment author email
+outputs:
+  document-path:
+    description: The relative path to the generated document
+    value: ${{ steps.document.outputs.path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      if: inputs.checkout-repo == 'true'
+      with:
+        fetch-depth: 0
+
+    - name: Get current and next major versions
+      id: versions
+      shell: bash
+      run: |
+        # Get the latest tag, strip the leading `v` if present, and extract the major version
+        current=$(git describe --tags --abbrev=0 | sed 's/^v//' |  grep -oE '^([0-9]+)')
+        next="$((current + 1))"
+
+        echo "current_major=$current" >> "$GITHUB_OUTPUT"
+        echo "next_major=$next" >> "$GITHUB_OUTPUT"
+
+    - name: Generate document
+      id: generate
+      shell: bash
+      run: |
+        CURRENT_MAJOR=${{ steps.versions.outputs.current_major }}
+        NEXT_MAJOR=${{ steps.versions.outputs.next_major }}
+        OUTPUT_FILE=docs/breaking-changes/v"$NEXT_MAJOR".md
+        curl -s ${{ inputs.template-url }} --output "$OUTPUT_FILE"
+
+        sed -i.bak -r "s/[-_*][-_*]CURRENT[-_*][-_*]/${CURRENT_MAJOR}/g" "$OUTPUT_FILE"
+        sed -i.bak -r "s/[-_*][-_*]NEXT[-_*][-_*]/${NEXT_MAJOR}/g" "$OUTPUT_FILE"
+
+        rm -f "$OUTPUT_FILE".bak
+
+        echo "document-path=$OUTPUT_FILE" >> "$GITHUB_OUTPUT"
+
+    - name: Check for changes
+      uses: dorny/paths-filter@v2
+      id: document
+      with:
+        filters: |
+          path: &path
+            - docs/breaking-changes/v${{ steps.versions.outputs.next_major }}.md
+          added:
+            - added: *path
+          modified:
+            - modified: *path
+
+    - name: Push added document
+      if: steps.document.outputs.added == 'true' && inputs.pr-comment == 'true'
+      uses: EndBug/add-and-commit@v9
+      with:
+        add: "docs/breaking-changes/v${{ steps.versions.outputs.next_major }}.md"
+        author_name: ${{ inputs.pr-comment-author-name }}
+        author_email: ${{ inputs.pr-comment-author-email }}
+        message: "fix(documentation): add breaking-changes template for v${{ steps.versions.outputs.next_major }} - automatic"
+        push: origin HEAD:${{ github.head_ref }}
+
+    - name: Notify owner to update document
+      if: steps.document.outputs.added == 'true'
+      uses: unsplash/comment-on-pr@master
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      with:
+        msg: |
+          ## 📄 Breaking change document generated
+
+          **Breaking changes were detected in this pull request**.
+
+          A breaking changes document was generated and pushed to this branch at `docs/breaking-changes/v${{ steps.versions.outputs.next_major }}.md`.
+
+          Please update the document before merging this pull request.


### PR DESCRIPTION

**Description**

Added an action which generates a `docs/breaking-changes/v${MAJOR_VERSION}.md` document and makes sure it's been modified from the template.
Would be nice to make the path and file name configurable with some sort of string format.  The PR message should also be more configurable.


**Changes**

* feat: add action to generate and validate breaking changes document

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
