### PR TITLE
fix(generate-breaking-changes-doc): ensure dir exists

### DIFF
--- a/generate-breaking-changes-doc/action.yaml
+++ b/generate-breaking-changes-doc/action.yaml
@@ -53,7 +53,9 @@ runs:
       run: |
         CURRENT_MAJOR=${{ steps.versions.outputs.current_major }}
         NEXT_MAJOR=${{ steps.versions.outputs.next_major }}
-        OUTPUT_FILE=docs/breaking-changes/v"$NEXT_MAJOR".md
+        OUTPUT_FOLDER=docs/breaking-changes
+        OUTPUT_FILE="$OUTPUT_FOLDER/v$NEXT_MAJOR.md"
+        mkdir -p "$OUTPUT_FOLDER"
         curl -s ${{ inputs.template-url }} --output "$OUTPUT_FILE"
 
         sed -i.bak -r "s/[-_*][-_*]CURRENT[-_*][-_*]/${CURRENT_MAJOR}/g" "$OUTPUT_FILE"


### PR DESCRIPTION

**Description**

The check fails if the `docs/breaking-changes` folder doesn't exist.

**Changes**

* fix(generate-breaking-changes-doc): ensure dir exists

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
