### PR TITLE
Modernize repo with latest standards

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["github>open-turo/renovate-config#v1"]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  push:
     branches: [main]
 
 jobs:

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -1,0 +1,25 @@
+name: Update dependencies
+concurrency: update-dependencies
+
+on:
+  schedule:
+    # Every day at midnight
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+  issue_comment:
+    types:
+      - edited
+  pull_request:
+    types:
+      - edited
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    name: Update dependencies
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: open-turo/action-renovate@v1
+        with:
+          github-token: ${{ secrets.OPEN_TURO_GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,10 @@ repos:
     rev: v1.6.8
     hooks:
       - id: actionlint
+  - repo: local
+    hooks:
+      - id: update-action-readme
+        name: update-action-readme
+        entry: ./script/update-action-readme
+        language: script
+        files: '.*/action\.yaml$'

--- a/auth/README.md
+++ b/auth/README.md
@@ -1,8 +1,12 @@
-# GitHub Action Auth
+# GitHub Action: Prerelease
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
 ## Description
 
 GitHub Action that conditionally creates the Terraform command line interface config file that is used to authenticate with Terraform. Created only if not found.
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Usage
 
@@ -17,19 +21,37 @@ jobs:
           terraform-cli-credentials-token: ${{ secrets.TCCT }}
 ```
 
+**IMPORTANT**: `GITHUB_TOKEN` does not have the required permissions to operate on protected branches.
+If you are using this action for protected branches, replace `GITHUB_TOKEN`
+with [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).
+If using the `@semantic-release/git` plugin for protected branches, avoid persisting credentials as part
+of `actions/checkout@v4` by setting the parameter `persist-credentials: false`. This credential does not have the
+required permission to operate on protected branches.
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
 ## Inputs
 
-| parameter                       | description                                    | required | default      |
-| ------------------------------- | ---------------------------------------------- | -------- | ------------ |
-| terraform-cli-credentials-token | The terraform cli config credentials token     | `true`   |              |
-| terraform-cli-config-file       | Relative path to the terraform cli config file | `false`  | .terraformrc |
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| terraform-cli-credentials-token | The terraform cli config credentials token | `true` |  |
+| terraform-cli-config-file | Relative path to the terraform cli config file | `false` | .terraformrc |
+<!-- action-docs-inputs -->
 
+<!-- action-docs-outputs -->
 ## Outputs
 
-| parameter                         | description                                                       |
-| --------------------------------- | ----------------------------------------------------------------- |
+| parameter | description |
+| --- | --- |
 | terraform-cli-config-file-created | Indicates whether or not this action created the cli config file. |
+<!-- action-docs-outputs -->
 
+<!-- action-docs-runs -->
 ## Runs
 
-This action is an `composite` action.
+This action is a `composite` action.
+<!-- action-docs-runs -->
+
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/check-for-breaking-changes/README.md
+++ b/check-for-breaking-changes/README.md
@@ -1,8 +1,12 @@
-# GitHub Action Check for Breaking Changes
+# GitHub Action: Prerelease
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
 ## Description
 
 GitHub Action that check the current branch for any breaking change commits based on the commit message.
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Usage
 
@@ -14,21 +18,39 @@ jobs:
         uses: open-turo/actions-tf/check-for-breaking-changes@v3
 ```
 
+**IMPORTANT**: `GITHUB_TOKEN` does not have the required permissions to operate on protected branches.
+If you are using this action for protected branches, replace `GITHUB_TOKEN`
+with [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).
+If using the `@semantic-release/git` plugin for protected branches, avoid persisting credentials as part
+of `actions/checkout@v4` by setting the parameter `persist-credentials: false`. This credential does not have the
+required permission to operate on protected branches.
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
 ## Inputs
 
-| parameter          | description                              | required | default                                          |
-| ------------------ | ---------------------------------------- | -------- | ------------------------------------------------ |
-| checkout-repo      | Perform checkout as first step of action | `false`  | true                                             |
-| commit-base-ref    | Commit range to exclude from check       | `false`  | $GITHUB_BASE_REF                                 |
-| commit-head-ref    | Commit range to include in check         | `false`  | $GITHUB_HEAD_REF                                 |
-| commit-msg-pattern | Pattern used to check                    | `false`  | 'BREAKING:\|BREAKING CHANGE:\|BREAKING CHANGES:' |
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| commit-base-ref | Commit range to exclude from check | `false` | $GITHUB_BASE_REF |
+| commit-head-ref | Commit range to include in check | `false` | $GITHUB_HEAD_REF |
+| commit-msg-pattern | Pattern used to check | `false` | BREAKING:\|BREAKING CHANGE:\|BREAKING CHANGES: |
+<!-- action-docs-inputs -->
 
+<!-- action-docs-outputs -->
 ## Outputs
 
-| parameter                 | description                                                                          |
-| ------------------------- | ------------------------------------------------------------------------------------ |
-| contains-breaking-changes | Indicates whether or not the action found a ny breaking changes in the commit range. |
+| parameter | description |
+| --- | --- |
+| contains-breaking-changes | Indicates whether or not the action found any breaking changes in the commit range. |
+<!-- action-docs-outputs -->
 
+<!-- action-docs-runs -->
 ## Runs
 
-This action is an `composite` action.
+This action is a `composite` action.
+<!-- action-docs-runs -->
+
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/generate-breaking-changes-doc/README.md
+++ b/generate-breaking-changes-doc/README.md
@@ -1,14 +1,12 @@
-# GitHub Action Generate Breaking Changes Document
+# GitHub Action: Prerelease
 
+<!-- prettier-ignore-start -->
 <!-- action-docs-description -->
-
 ## Description
 
 GitHub Action that creates a breaking changes document based on the configured template.
-
 <!-- action-docs-description -->
-
-\_\_
+<!-- prettier-ignore-end -->
 
 ## Usage
 
@@ -37,35 +35,41 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-<!-- action-docs-inputs -->
+**IMPORTANT**: `GITHUB_TOKEN` does not have the required permissions to operate on protected branches.
+If you are using this action for protected branches, replace `GITHUB_TOKEN`
+with [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).
+If using the `@semantic-release/git` plugin for protected branches, avoid persisting credentials as part
+of `actions/checkout@v4` by setting the parameter `persist-credentials: false`. This credential does not have the
+required permission to operate on protected branches.
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
 ## Inputs
 
-| parameter               | description                                                                                                 | required | default                                                                                                         |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
-| checkout-repo           | Perform checkout as first step of action                                                                    | `false`  | true                                                                                                            |
-| github-token            | GitHub token that can checkout the consumer repository as well push against it. e.g. 'secrets.GITHUB_TOKEN' | `true`   |                                                                                                                 |
-| template-url            | Breaking changes document template URL                                                                      | `false`  | https://raw.githubusercontent.com/open-turo/standards-terraform/main/templates/breaking-changes-doc-template.md |
-| pr-comment              | Adds a comment to the pull request informing that the breaking changes document was added                   | `false`  | true                                                                                                            |
-| pr-comment-author-name  | The pull request comment author name                                                                        | `false`  |                                                                                                                 |
-| pr-comment-author-email | The pull request comment author email                                                                       | `false`  |                                                                                                                 |
-
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| github-token | GitHub token that can checkout the consumer repository as well push against it. e.g. 'secrets.GITHUB_TOKEN' | `true` |  |
+| template-url | Breaking changes document template URL | `false` | https://raw.githubusercontent.com/open-turo/standards-terraform/main/templates/breaking-changes-doc-template.md |
+| pr-comment | Adds a comment to the pull request informing that the breaking changes document was added | `false` | true |
+| pr-comment-author-name | The pull request comment author name | `false` |  |
+| pr-comment-author-email | The pull request comment author email | `false` |  |
 <!-- action-docs-inputs -->
 
 <!-- action-docs-outputs -->
-
 ## Outputs
 
-| parameter     | description                                 |
-| ------------- | ------------------------------------------- |
+| parameter | description |
+| --- | --- |
 | document-path | The relative path to the generated document |
-
 <!-- action-docs-outputs -->
 
 <!-- action-docs-runs -->
-
 ## Runs
 
 This action is a `composite` action.
-
 <!-- action-docs-runs -->
+
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/lint/README.md
+++ b/lint/README.md
@@ -1,8 +1,12 @@
-# GitHub Action Lint
+# GitHub Action: Prerelease
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
 ## Description
 
 GitHub Action that lints a Terraform based repository via [action-pre-commit](https://github.com/open-turo/action-pre-commit)
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Usage
 
@@ -17,25 +21,34 @@ jobs:
           terraform-cli-credentials-token: ${{ secrets.TCCT }}
 ```
 
+**IMPORTANT**: `GITHUB_TOKEN` does not have the required permissions to operate on protected branches.
+If you are using this action for protected branches, replace `GITHUB_TOKEN`
+with [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).
+If using the `@semantic-release/git` plugin for protected branches, avoid persisting credentials as part
+of `actions/checkout@v4` by setting the parameter `persist-credentials: false`. This credential does not have the
+required permission to operate on protected branches.
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
 ## Inputs
 
-| parameter                       | description                                                | required | default        |
-| ------------------------------- | ---------------------------------------------------------- | -------- | -------------- |
-| checkout-repo                   | Perform checkout as first step of action                   | `false`  | true           |
-| terraform-cli-credentials-token | The terraform cli config credentials token                 | `true`   |                |
-| terraform-cli-config-file       | Relative or absolute path to the terraform cli config file | `false`  | ./.terraformrc |
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| terraform-cli-credentials-token | The terraform cli config credentials token | `true` |  |
+| terraform-cli-config-file | Relative path to the terraform cli config file | `false` | .terraformrc |
+<!-- action-docs-inputs -->
 
+<!-- action-docs-outputs -->
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-runs -->
 ## Runs
 
-This action is an `composite` action.
+This action is a `composite` action.
+<!-- action-docs-runs -->
 
-## Lint Checks
-
-This action runs the following lint checks:
-
-- [action-pre-commit](https://github.com/open-turo/action-pre-commit)
-
-## Notes
-
-- By default, this action will perform actions/checkout as its first step.
-- This expects that the `.commitlintrc.yaml` file will be present at the root level of the consumer repository to enforce [`conventional-commit`](https://github.com/wagoid/commitlint-github-action).
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -33,6 +33,9 @@ runs:
       uses: open-turo/action-setup-tools@v2
     - name: Pre-commit
       uses: open-turo/action-pre-commit@v1
+    - name: Check release notes on pull_request
+      if: github.event_name == 'pull_request'
+      uses: open-turo/actions-release/lint-release-notes@v4
     - name: Post run
       if: always() && ${{ steps.create-credentials-file.outputs.terraform-cli-config-file-created }}
       shell: bash

--- a/prerelease/README.md
+++ b/prerelease/README.md
@@ -4,7 +4,7 @@
 <!-- action-docs-description -->
 ## Description
 
-< GitHub Action to compute a prerelease version based on the latest release version and the number of commits since the latest release. This will also generate a docker tag based on the computed version if the label `prerelease` is specified on the PR.
+GitHub Action to compute a prerelease version based on the latest release version and the number of commits since the latest release.
 <!-- action-docs-description -->
 <!-- prettier-ignore-end -->
 
@@ -40,14 +40,9 @@ required permission to operate on protected branches.
 | parameter | description | required | default |
 | --- | --- | --- | --- |
 | checkout-repo | Perform checkout as first step of action | `false` | true |
-| create-prerelease | Whether semantic-release should create a prerelease or do a dry run. This can be useful to set to true when a prerelease requires pushing artifacts semantic-release is in charge of generating | `false` | false |
-| docker-config-file | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile. | `false` | .docker-config.json |
-| dockerhub-user | username for dockerhub | `true` |  |
-| dockerhub-password | password for dockerhub | `true` |  |
+| create-prerelease | Whether semantic-release should create a prerelease or do a dry run. This can be useful to set to true when a prerelease requires pushing artifacts semantic-release is in charge of generating | `false` | true |
 | github-token | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true` |  |
 | extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config. | `false` | @open-turo/semantic-release-config  |
-| artifactory-username | Artifactory user name usually secrets.ARTIFACTORY_USERNAME | `true` |  |
-| artifactory-auth-token | Artifactory auth token usually secrets.ARTIFACTORY_AUTH_TOKEN | `true` |  |
 <!-- action-docs-inputs -->
 
 <!-- action-docs-outputs -->
@@ -58,8 +53,6 @@ required permission to operate on protected branches.
 | new-release-published | Whether a new release was published |
 | new-release-version | Version of the new release |
 | new-release-major-version | Major version of the new release |
-| image-name | Docker image name |
-| image-with-tag | Full image with tag - <image-name>:<image-version> |
 | pull-request-number | Pull request number |
 | run-url | URL to the GHA run |
 <!-- action-docs-outputs -->

--- a/release/README.md
+++ b/release/README.md
@@ -1,16 +1,12 @@
-# GitHub Action Release
+# GitHub Action: Prerelease
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
 ## Description
 
 GitHub Action that produces a new Release of a Terraform based repository.
-
-## Configuration
-
-### Step1: Set any [Semantic Release Configuration](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration) in the consumer repository.
-
-### Step2: [Add Secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) in the consumer repository for the [Semantic Release Authentication](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/ci-configuration.md#authentication) Environment Variables.
-
-### Step3: Add a [Workflow File](https://help.github.com/en/articles/workflow-syntax-for-github-actions) to the consumer repository to create custom automated processes.
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Usage
 
@@ -24,95 +20,41 @@ steps:
 ```
 
 **IMPORTANT**: `GITHUB_TOKEN` does not have the required permissions to operate on protected branches.
-If you are using this action for protected branches, replace `GITHUB_TOKEN` with [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). If using the `@semantic-release/git` plugin for protected branches, avoid persisting credentials as part of `actions/checkout@v3` by setting the parameter `persist-credentials: false`. This credential does not have the required permission to operate on protected branches.
+If you are using this action for protected branches, replace `GITHUB_TOKEN`
+with [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).
+If using the `@semantic-release/git` plugin for protected branches, avoid persisting credentials as part
+of `actions/checkout@v4` by setting the parameter `persist-credentials: false`. This credential does not have the
+required permission to operate on protected branches.
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
 ## Inputs
 
-| parameter     | description                                                                                                                    | required | default |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------- | ------- |
-| checkout-repo | Perform checkout as first step of action                                                                                       | `false`  | true    |
-| github-token  | GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
-| dry-run       | Whether to run semantic release in `dry-run` mode. It will override the dryRun attribute in your configuration file            | `false`  |         |
-| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.              | `false`  |         |
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| checkout-fetch-depth | The number of commits to fetch. 0 indicates all history for all branches and tags | `false` | 0 |
+| github-token | GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true` |  |
+| dry-run | Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file | `false` | false |
+| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config. | `false` | @open-turo/semantic-release-config  |
+<!-- action-docs-inputs -->
 
+<!-- action-docs-outputs -->
 ## Outputs
 
-| parameter                 | description                         |
-| ------------------------- | ----------------------------------- |
-| new-release-published     | Whether a new release was published |
-| new-release-version       | Version of the new release          |
-| new-release-major-version | Major version of the new release    |
+| parameter | description |
+| --- | --- |
+| new-release-published | Whether a new release was published |
+| new-release-version | Version of the new release |
+| new-release-major-version | Major version of the new release |
+<!-- action-docs-outputs -->
 
+<!-- action-docs-runs -->
 ## Runs
 
-This action is an `composite` action.
+This action is a `composite` action.
+<!-- action-docs-runs -->
 
-## Additional Examples
-
-### extra-plugins example
-
-This Action can be used with the `extra-plugins` option to specify plugins which are not in the [default list of plugins of semantic release](https://semantic-release.gitbook.io/semantic-release/usage/plugins#default-plugins). When using this option, please make sure that these plugins are also mentioned in your [semantic release config's plugins](https://semantic-release.gitbook.io/semantic-release/usage/configuration#plugins) array.
-
-For example, if you want to use `@semantic-release/git` and `@semantic-release/changelog` extra plugins, these must be added to `extra-plugins` in the step where this Action is called and `plugins` in your [release config file](https://semantic-release.gitbook.io/semantic-release/usage/configuration#configuration-file) as shown below:
-
-#### Github Action Workflow
-
-```yaml
-steps:
-  - name: Release
-    uses: open-turo/actions-tf/release@v3
-    with:
-      # You can specify specifying version range for the extra plugins if you prefer.
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-      extra-plugins: |
-        @semantic-release/changelog@3.0.0
-        @semantic-release/git
-```
-
-Similar to parameter `semantic_version`. _It is recommended to manually specify a version of semantic-release plugins to prevent errors caused._
-
-#### Release Configuration (.releaserc.json)
-
-```diff
-  plugins: [
-    .
-+   "@semantic-release/changelog"
-+   "@semantic-release/git",
-  ]
-```
-
-### dry-run example
-
-```yaml
-jobs:
-  build:
-    steps:
-      - name: Release
-        uses: open-turo/actions-tf/release@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          dry-run: true
-```
-
-### using output parameters example
-
-```yaml
-jobs:
-  build:
-    steps:
-      - name: Release
-        uses: open-turo/actions-tf/release@v3
-        # id element needed to reference step outputs
-        id: release
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Do something when a new release published
-        if: steps.release.outputs.new-release-published == 'true'
-        run: |
-          echo ${{ steps.release.outputs.new-release-version }}
-          echo ${{ steps.release.outputs.new-release-major-version }}
-```
-
-## Notes
-
-- By default, this action will perform actions/checkout as its first step.
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -5,17 +5,22 @@ inputs:
     required: false
     description: Perform checkout as first step of action
     default: "true"
+  checkout-fetch-depth:
+    required: false
+    description: The number of commits to fetch. 0 indicates all history for all branches and tags
+    default: "0"
   github-token:
     required: true
     description: GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'
   dry-run:
     required: false
-    description: Whether to run semantic release in `dry-run` mode. It will override the dryRun attribute in your configuration file
+    description: Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file
+    default: "false"
   extra-plugins:
     required: false
     description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.
     default: |
-      @open-turo/semantic-release-config@^1.4.0
+      @open-turo/semantic-release-config
 outputs:
   new-release-published:
     description: Whether a new release was published
@@ -30,18 +35,33 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: inputs.checkout-repo == 'true'
       with:
-        # Use fetch-depth of zero to obtain all commit history so that semantic versioning can be properly
-        # performed to arrive at the next version number that is to be released.
-        fetch-depth: 0
+        fetch-depth: ${{ inputs.checkout-fetch-depth }}
+        persist-credentials: false
     - name: Setup tools
       uses: open-turo/action-setup-tools@v2
-    - name: Release
-      uses: cycjimmy/semantic-release-action@v3
+    - uses: 8BitJonny/gh-get-current-pr@2.2.0
+      id: PR
       with:
-        dry_run: ${{ inputs.dry-run }}
-        extra_plugins: ${{ inputs.extra-plugins }}
+        sha: ${{ steps.source-vars.outputs.sha }}
+    - name: Branches configuration
+      id: branches-configuration
+      shell: bash
+      run: |
+        if [ -z "${{ steps.PR.outputs.number }}" ]; then
+          echo "branches=${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
+        else
+          echo "branches=[\"${{ github.event.repository.default_branch }}\", {\"name\": \"${{ github.ref_name }}\",\"channel\": \"next\",\"prerelease\": \"pr-${{ steps.PR.outputs.number }}.${{ github.run_number }}.${{ github.run_attempt }}\"}]" >> $GITHUB_OUTPUT
+        fi
+    - name: Release
+      id: release
+      uses: open-turo/actions-release/semantic-release@v4
+      with:
+        branches: ${{ steps.branches-configuration.outputs.branches }}
+        dry-run: ${{ inputs.dry-run }}
+        extra-plugins: ${{ inputs.extra-plugins }}
+        github-token: ${{ inputs.github-token }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/script/update-action-readme
+++ b/script/update-action-readme
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+for i in $*; do
+  # ignore if the file does not end with /action.yaml
+  if [[ "$i" != *"/action.yaml" ]]; then
+    echo "skipping: ${i}"
+    continue
+  fi
+  readme_file=$(dirname "$i")/README.md
+  echo "npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}""
+  npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}"
+done


### PR DESCRIPTION

**Description**

See each commit below for details



**Changes**

* ci: replace dependabot with renovatebot
* feat(lint): add lint-release-notes step
* feat(release): use open-turo action and latest release config as default
* ci(pre-commit): add action-docs
* docs: generate action readmes using action-docs

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
