### PR TITLE
ci: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @open-turo/github-actions


### PR DESCRIPTION

**Description**


The repo is missing them and we are not looking at the renovatebot PRs


**Changes**

* ci: add codeowners

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
