### PR TITLE
DEVOPS-11443: As a DevOps, I want to upgrade action-pre-commit to v3

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -32,7 +32,7 @@ runs:
       # Provide opportunity to install terraform, golang, and others
       uses: open-turo/action-setup-tools@v2
     - name: Pre-commit
-      uses: open-turo/action-pre-commit@v2
+      uses: open-turo/action-pre-commit@v3
     - name: Check release notes on pull_request
       if: github.event_name == 'pull_request'
       uses: open-turo/actions-release/lint-release-notes@v4


### PR DESCRIPTION

**Description**

- upgrade action-pre-commit to v3 for lint job

Fixes [#DEVOPS-11443](https://team-turo.atlassian.net/browse/DEVOPS-11443)

**Changes**

* feat(dependency): upgrade action-pre-commit to v3 for lint job

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)