### PR TITLE
feat: add support to cache pre-commit in s3

### DIFF
--- a/lint/README.md
+++ b/lint/README.md
@@ -21,6 +21,23 @@ jobs:
           terraform-cli-credentials-token: ${{ secrets.TCCT }}
 ```
 
+You can specify an S3 bucket to cache dependencies in order to speed up runs, in which case you will need to configure AWS credentials like so:
+
+```yaml
+jobs:
+  build:
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - uses: open-turo/actions-tf/lint@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          s3-bucket-name: <bucket-name>
+          s3-bucket-region: us-east-1
+```
+
 **IMPORTANT**: `GITHUB_TOKEN` does not have the required permissions to operate on protected branches.
 If you are using this action for protected branches, replace `GITHUB_TOKEN`
 with [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -12,6 +12,12 @@ inputs:
     required: false
     description: Relative path to the terraform cli config file
     default: .terraformrc
+  s3-bucket-name:
+    required: false
+    description: S3 bucket name to cache dependencies to speed up runs.
+  s3-bucket-region:
+    required: false
+    description: S3 bucket region to cache dependencies to speed up runs.
 runs:
   using: composite
   steps:
@@ -33,6 +39,9 @@ runs:
       uses: open-turo/action-setup-tools@v2
     - name: Pre-commit
       uses: open-turo/action-pre-commit@v3
+      with:
+        s3-bucket-name: ${{ inputs.s3-bucket-name }}
+        s3-bucket-region: ${{ inputs.s3-bucket-region }}
     - name: Check release notes on pull_request
       if: github.event_name == 'pull_request'
       uses: open-turo/actions-release/lint-release-notes@v4


### PR DESCRIPTION

**Description**

This PR follows suit from https://github.com/open-turo/actions-node/tree/main/lint to allow to configure these actions to cache pre-commit (and future other deps) in S3 to speed up runs.

**Changes**

* feat: add support to cache pre-commit in s3

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
