### PR TITLE
fix(test): set the terraform rc file path as env var

### DIFF
--- a/auth/action.yaml
+++ b/auth/action.yaml
@@ -23,6 +23,7 @@ runs:
       shell: bash
       run: |
         CREDENTIAL_FILE="$HOME/${{ inputs.terraform-cli-config-file }}"
+        echo "TF_CLI_CONFIG_FILE=$CREDENTIAL_FILE" >> $GITHUB_ENV
         if [[ -f "$CREDENTIAL_FILE" ]]; then
           echo "file-created=false" >> $GITHUB_OUTPUT
           echo "Terraform credentials already present, skipping."

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -43,17 +43,11 @@ runs:
       run: |
         echo "TF_PLUGIN_CACHE_DIR=${{ runner.temp }}/.terraform.d/plugin-cache" >>"$GITHUB_ENV"
         mkdir --parents "${{ runner.temp }}/.terraform.d/plugin-cache"
-    - name: Check for terraform lockfiles
-      id: check_terraform_lockfiles
-      if: inputs.s3-bucket-name != ''
-      uses: andstor/file-existence-action@v3
-      with:
-        files: "**/.terraform.lock.hcl"
     - name: Compute terraform plugin cache key
       if: inputs.s3-bucket-name != ''
       id: tf_plugin_cache_key
       run: |
-        echo "key=terraform-${{ runner.os }}-${{ steps.check_terraform_lockfiles.outputs.files_exists == 'true' && hashFiles('**/.terraform.lock.hcl') || hashFiles('**/terraform.tf') }}" >> $GITHUB_OUTPUT
+        echo "key=terraform-${{ runner.os }}-${{ hashFiles('**/.terraform.lock.hcl', '**/terraform.tf', '**/versions.tf') }}" >> $GITHUB_OUTPUT
       shell: bash
     - name: Load cached terraform plugins if available
       if: inputs.s3-bucket-name != ''

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -80,7 +80,6 @@ runs:
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
-        TF_CLI_CONFIG_FILE: ${{ inputs.terraform-cli-config-file }}
         ATLAS_TOKEN: ${{ inputs.terraform-cli-credentials-token }}
     - name: Post run
       if: always() && ${{ steps.create-credentials-file.outputs.terraform-cli-config-file-created }}


### PR DESCRIPTION
Trying to fix the problem where we've been seeing:
```
There are some problems with the CLI configuration:
╷
│ Warning: Unable to open CLI configuration file
│
│ The CLI configuration file at ".terraformrc" does not exist.
╵
```