### PR TITLE
DEVX-63: Add GH setup actions to action-setup-tools

### DIFF
--- a/docs/breaking-changes/v4.md
+++ b/docs/breaking-changes/v4.md
@@ -1,0 +1,26 @@
+# Breaking changes in v4
+
+[//]: # "Upgrade to action-setup-tools@v3. This introduces a major internal refactor by removing custom tool installers in favor of official GitHub setup actions."
+
+## Description of changes
+
+This repository now uses \`action-setup-tools@v3\`, which has dropped support for custom install scripts like \`pyenv\`, \`nodenv\`, \`sdkman\`, and \`tfenv\`.
+
+Tool installation is now handled by the official GitHub Setup Actions:
+
+- [actions/setup-node](https://github.com/actions/setup-node)
+- [actions/setup-python](https://github.com/actions/setup-python)
+- [actions/setup-java](https://github.com/actions/setup-java)
+- [hashicorp/setup-terraform](https://github.com/hashicorp/setup-terraform)
+
+These official actions improve compatibility and maintainability, but may result in slightly different behaviors around version resolution or caching.
+
+## Upgrade instructions
+
+No code changes are required for most users.
+
+Version files like \`.nvmrc\`, \`.sdkmanrc\`, and \`.python-version\` are still supported and will continue to work.
+
+However, if you previously relied on custom logic from the removed installers (e.g., local shims, caching behavior), you should validate that workflows behave as expected with the new setup actions.
+
+If you're overriding default versions or using custom tooling logic, we recommend running a test workflow to confirm compatibility.

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -36,7 +36,7 @@ runs:
         terraform-cli-config-file: ${{ inputs.terraform-cli-config-file }}
     - name: Setup tools
       # Provide opportunity to install terraform, golang, and others
-      uses: open-turo/action-setup-tools@v2
+      uses: open-turo/action-setup-tools@v3
 
     - name: Configure Terraform plugin cache
       shell: bash

--- a/prerelease/action.yaml
+++ b/prerelease/action.yaml
@@ -115,7 +115,7 @@ runs:
         echo "::debug::labels.contains('prerelease'): ${{ contains(toJSON(fromJSON(steps.PR.outputs.pr).labels.*.name), 'prerelease') }}"
 
     # Compute next release
-    - uses: open-turo/action-setup-tools@v2
+    - uses: open-turo/action-setup-tools@v3
       if: steps.check-pr.outputs.has_prerelease_label == 'true'
 
     - name: Prerelease

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -41,7 +41,7 @@ runs:
         fetch-depth: ${{ inputs.checkout-fetch-depth }}
         persist-credentials: false
     - name: Setup tools
-      uses: open-turo/action-setup-tools@v2
+      uses: open-turo/action-setup-tools@v3
     - uses: 8BitJonny/gh-get-current-pr@3.0.0
       id: PR
       with:

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -39,7 +39,9 @@ runs:
         terraform-cli-config-file: ${{ inputs.terraform-cli-config-file }}
     - name: Setup tools
       # Provide opportunity to install terraform, golang, and others
-      uses: open-turo/action-setup-tools@v2
+      uses: open-turo/action-setup-tools@v3
+      with:
+        node: 20
     - name: Verify required repository files
       shell: bash
       run: |


### PR DESCRIPTION
**Description**
Add GH setup actions to action-setup-tools for testing

note that node version 20 is needed for go test to work, so it's specified in the test job.

**Changes**

* test(gha): test gh setup action

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
