### PR TITLE
fix: prevent shell injection vulnerabilities (SEC-4316)

### DIFF
--- a/auth/action.yaml
+++ b/auth/action.yaml
@@ -21,13 +21,16 @@ runs:
     - name: Create credentials file if missing
       id: create
       shell: bash
+      env:
+        TF_CLI_CONFIG_FILE: ${{ inputs.terraform-cli-config-file }}
+        TF_CLI_CREDENTIALS_TOKEN: ${{ inputs.terraform-cli-credentials-token }}
       run: |
-        CREDENTIAL_FILE="$HOME/${{ inputs.terraform-cli-config-file }}"
+        CREDENTIAL_FILE="$HOME/$TF_CLI_CONFIG_FILE"
         echo "TF_CLI_CONFIG_FILE=$CREDENTIAL_FILE" >> $GITHUB_ENV
         if [[ -f "$CREDENTIAL_FILE" ]]; then
           echo "file-created=false" >> $GITHUB_OUTPUT
           echo "Terraform credentials already present, skipping."
           exit 0
         fi
-        echo -e "credentials \"app.terraform.io\" {\ntoken = \"${{ inputs.terraform-cli-credentials-token }}\"\n}" > "$CREDENTIAL_FILE"
+        echo -e "credentials \"app.terraform.io\" {\ntoken = \"$TF_CLI_CREDENTIALS_TOKEN\"\n}" > "$CREDENTIAL_FILE"
         echo "file-created=true" >> $GITHUB_OUTPUT

--- a/check-for-breaking-changes/action.yaml
+++ b/check-for-breaking-changes/action.yaml
@@ -34,10 +34,14 @@ runs:
     - name: Check for breaking changes
       id: check
       shell: bash
+      env:
+        COMMIT_BASE_REF: ${{ inputs.commit-base-ref }}
+        COMMIT_HEAD_REF: ${{ inputs.commit-head-ref }}
+        COMMIT_MSG_PATTERN: ${{ inputs.commit-msg-pattern }}
       run: |
-        commits=$(git log origin/"${{ inputs.commit-base-ref }}"..origin/"${{ inputs.commit-head-ref }}")
+        commits=$(git log origin/"$COMMIT_BASE_REF"..origin/"$COMMIT_HEAD_REF")
 
-        if echo "$commits" | grep -q "${{ inputs.commit-msg-pattern }}"; then
+        if echo "$commits" | grep -q "$COMMIT_MSG_PATTERN"; then
           echo "contains-breaking=true" >> "$GITHUB_OUTPUT"
         else
           echo "contains-breaking=false" >> "$GITHUB_OUTPUT"

--- a/generate-breaking-changes-doc/action.yaml
+++ b/generate-breaking-changes-doc/action.yaml
@@ -50,11 +50,15 @@ runs:
     - name: Generate document
       id: generate
       shell: bash
+      env:
+        CURRENT_MAJOR_VERSION: ${{ steps.versions.outputs.current_major }}
+        NEXT_MAJOR_VERSION: ${{ steps.versions.outputs.next_major }}
+        TEMPLATE_URL: ${{ inputs.template-url }}
       run: |
-        CURRENT_MAJOR=${{ steps.versions.outputs.current_major }}
-        NEXT_MAJOR=${{ steps.versions.outputs.next_major }}
+        CURRENT_MAJOR=$CURRENT_MAJOR_VERSION
+        NEXT_MAJOR=$NEXT_MAJOR_VERSION
         OUTPUT_FILE=docs/breaking-changes/v"$NEXT_MAJOR".md
-        curl -s ${{ inputs.template-url }} --output "$OUTPUT_FILE"
+        curl -s $TEMPLATE_URL --output "$OUTPUT_FILE"
 
         sed -i.bak -r "s/[-_*][-_*]CURRENT[-_*][-_*]/${CURRENT_MAJOR}/g" "$OUTPUT_FILE"
         sed -i.bak -r "s/[-_*][-_*]NEXT[-_*][-_*]/${NEXT_MAJOR}/g" "$OUTPUT_FILE"

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -76,4 +76,6 @@ runs:
     - name: Post run
       if: always() && ${{ steps.create-credentials-file.outputs.terraform-cli-config-file-created }}
       shell: bash
-      run: rm "$HOME/${{ inputs.terraform-cli-config-file }}" || true
+      env:
+        TF_CLI_CONFIG_FILE: ${{ inputs.terraform-cli-config-file }}
+      run: rm "$HOME/$TF_CLI_CONFIG_FILE" || true


### PR DESCRIPTION
## 🔒 Security Fix: Shell Injection Prevention

> **⚠️ This PR is in DRAFT status for review. Mark as "Ready for review" when approved.**

### Issue
Fixes **4 shell injection vulnerabilities** detected by Semgrep in GitHub Actions workflows.

**Jira**: [SEC-4316](https://team-turo.atlassian.net/browse/SEC-4316)  
**Semgrep Rule**: `yaml.github-actions.security.run-shell-injection.run-shell-injection`  
**Severity**: High  
**Findings**: 
- auth/action.yaml:24
- check-for-breaking-changes/action.yaml:37
- generate-breaking-changes-doc/action.yaml:53
- lint/action.yaml:79

### 🔍 What Changed
- Moved all GitHub Actions inputs to environment variables before use in shell scripts
- Prevents potential command injection attacks
- **Zero functional changes** - purely security hardening

### 🛡️ Security Context
Direct interpolation of `${{ inputs.* }}` in shell scripts can allow command injection if untrusted input is provided.

**Vulnerable Pattern**:
```yaml
run: |
  CREDENTIAL_FILE="$HOME/${{ inputs.terraform-cli-config-file }}"  # ❌ Can execute arbitrary commands
```

**Secure Pattern**:
```yaml
env:
  TF_CLI_CONFIG_FILE: ${{ inputs.terraform-cli-config-file }}
run: |
  CREDENTIAL_FILE="$HOME/$TF_CLI_CONFIG_FILE"  # ✅ Treated as data, not code
```

### 📚 References
- [GitHub Security Hardening for Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable)
- [Semgrep Findings](https://semgrep.dev/orgs/turo/findings?tab=open&confidence=high&severity=3%2C2&primary=true)

### ✅ Testing Checklist
- [x] All existing functionality preserved
- [x] No breaking changes to action interface
- [x] Workflow YAML syntax validated
- [x] Pre-commit checks passing

### 🎯 Review Checklist for Maintainer
- [ ] Review all file changes
- [ ] Verify environment variable naming is clear
- [ ] Confirm no functional regressions
- [ ] Check CI/CD results
- [ ] Mark as "Ready for review" when approved